### PR TITLE
Add Instructors button in header

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -19,6 +19,9 @@ export const Header = () => {
           Home
         </Link>
         <Link href="/faq" className="text-md font-medium hover:underline underline-offset-4" prefetch={false}>FAQ</Link>
+        <Link href="/about-us" className="text-md font-medium hover:underline underline-offset-4" prefetch={false}>
+          Instructors
+        </Link>
         <Link href="https://docs.google.com/forms/d/e/1FAIpQLSeysTaenp0vmB4qtWRXItMwY-m1_pmTrmalKPWZjt6P5ymUTw/viewform?usp=sf_link" className="text-md font-medium hover:underline underline-offset-4" prefetch={false}>
           Apply Now
         </Link>


### PR DESCRIPTION
Add a button labeled "Instructors" in the header linking to "/about-us".

* Add a new `Link` component with the label "Instructors" and set its `href` attribute to "/about-us".
* Place the new "Instructors" button between the "FAQ" and "Apply Now" links in the header.

